### PR TITLE
Update to React Native 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The easiest way to get started is to check out the example:
 ```
 cd example/ReduxRouter/
 npm install
+find node_modules -type f -name '.babelrc' | grep -v 'node_modules/react-native/packager/react-packager/.babelrc' | xargs rm
 react-native start
 ```
 

--- a/example/ReduxRouter/.flowconfig
+++ b/example/ReduxRouter/.flowconfig
@@ -7,12 +7,24 @@
 # Some modules have their own node_modules with overlap
 .*/node_modules/node-haste/.*
 
-# Ignore react-tools where there are overlaps, but don't ignore anything that
-# react-native relies on
-.*/node_modules/react-tools/src/React.js
-.*/node_modules/react-tools/src/renderers/shared/event/EventPropagators.js
-.*/node_modules/react-tools/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
-.*/node_modules/react-tools/src/shared/vendor/core/ExecutionEnvironment.js
+# Ugh
+.*/node_modules/babel.*
+.*/node_modules/babylon.*
+.*/node_modules/invariant.*
+
+# Ignore react and fbjs where there are overlaps, but don't ignore
+# anything that react-native relies on
+.*/node_modules/fbjs-haste/.*/__tests__/.*
+.*/node_modules/fbjs-haste/__forks__/Map.js
+.*/node_modules/fbjs-haste/__forks__/Promise.js
+.*/node_modules/fbjs-haste/__forks__/fetch.js
+.*/node_modules/fbjs-haste/core/ExecutionEnvironment.js
+.*/node_modules/fbjs-haste/core/isEmpty.js
+.*/node_modules/fbjs-haste/crypto/crc32.js
+.*/node_modules/fbjs-haste/stubs/ErrorUtils.js
+.*/node_modules/react-haste/React.js
+.*/node_modules/react-haste/renderers/dom/ReactDOM.js
+.*/node_modules/react-haste/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
 
 # Ignore commoner tests
 .*/node_modules/commoner/test/.*
@@ -43,9 +55,9 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(1[0-7]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(1[0-7]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(1[0-8]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(1[0-8]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-0.17.0
+0.18.1

--- a/example/ReduxRouter/android/app/build.gradle
+++ b/example/ReduxRouter/android/app/build.gradle
@@ -74,5 +74,5 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.14.+"
+    compile "com.facebook.react:react-native:0.16.+"
 }

--- a/example/ReduxRouter/android/app/react.gradle
+++ b/example/ReduxRouter/android/app/react.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 def config = project.hasProperty("react") ? project.react : [];
 
 def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
@@ -36,8 +38,13 @@ task bundleDebugJsAndAssets(type: Exec) {
 
     // set up the call to the react-native cli
     workingDir reactRoot
-    commandLine "react-native", "bundle", "--platform", "android", "--dev", "true", "--entry-file",
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine "cmd", "/c", "react-native", "bundle", "--platform", "android", "--dev", "true", "--entry-file",
             entryFile, "--bundle-output", jsBundleFileDebug, "--assets-dest", resourcesDirDebug
+    } else {
+        commandLine "react-native", "bundle", "--platform", "android", "--dev", "true", "--entry-file",
+            entryFile, "--bundle-output", jsBundleFileDebug, "--assets-dest", resourcesDirDebug
+    }
 
     enabled config.bundleInDebug ?: false
 }
@@ -56,8 +63,13 @@ task bundleReleaseJsAndAssets(type: Exec) {
 
     // set up the call to the react-native cli
     workingDir reactRoot
-    commandLine "react-native", "bundle", "--platform", "android", "--dev", "false", "--entry-file",
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine "cmd","/c", "react-native", "bundle", "--platform", "android", "--dev", "false", "--entry-file",
             entryFile, "--bundle-output", jsBundleFileRelease, "--assets-dest", resourcesDirRelease
+    } else {
+        commandLine "react-native", "bundle", "--platform", "android", "--dev", "false", "--entry-file",
+            entryFile, "--bundle-output", jsBundleFileRelease, "--assets-dest", resourcesDirRelease
+    }
 
     enabled config.bundleInRelease ?: true
 }

--- a/example/ReduxRouter/android/app/src/main/java/com/reduxrouter/MainActivity.java
+++ b/example/ReduxRouter/android/app/src/main/java/com/reduxrouter/MainActivity.java
@@ -72,7 +72,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
         super.onResume();
 
         if (mReactInstanceManager != null) {
-            mReactInstanceManager.onResume(this);
+            mReactInstanceManager.onResume(this, this);
         }
     }
 }

--- a/example/ReduxRouter/android/build.gradle
+++ b/example/ReduxRouter/android/build.gradle
@@ -16,5 +16,8 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
+        jcenter {
+            url "http://dl.bintray.com/mkonicek/maven"
+        }
     }
 }

--- a/example/ReduxRouter/app/components/Master.js
+++ b/example/ReduxRouter/app/components/Master.js
@@ -2,7 +2,7 @@
 
 import React, { Component, Image, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
-export default Master = (backgroundColor = '#F5FCFF') => class extends Component {
+const Master = (backgroundColor = '#F5FCFF') => class extends Component {
   render() {
     const { actions, assets } = this.props;
 
@@ -16,6 +16,8 @@ export default Master = (backgroundColor = '#F5FCFF') => class extends Component
     );
   }
 }
+
+export default Master
 
 var styles = StyleSheet.create({
   container: {

--- a/example/ReduxRouter/ios/ReduxRouter/AppDelegate.m
+++ b/example/ReduxRouter/ios/ReduxRouter/AppDelegate.m
@@ -47,7 +47,7 @@
                                                    launchOptions:launchOptions];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [[UIViewController alloc] init];
+  UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/example/ReduxRouter/ios/ReduxRouterTests/ReduxRouterTests.m
+++ b/example/ReduxRouter/ios/ReduxRouterTests/ReduxRouterTests.m
@@ -42,7 +42,7 @@
   BOOL foundElement = NO;
 
   __block NSString *redboxError = nil;
-  RCTSetLogFunction(^(RCTLogLevel level, NSString *fileName, NSNumber *lineNumber, NSString *message) {
+  RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
     if (level >= RCTLogLevelError) {
       redboxError = message;
     }

--- a/example/ReduxRouter/package.json
+++ b/example/ReduxRouter/package.json
@@ -6,7 +6,7 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "react-native": "^0.14.2",
+    "react-native": "^0.16.0",
     "react-native-router-redux": "^0.2.1",
     "react-redux": "^3.1.0",
     "redux": "^3.0.4"

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -28,7 +28,7 @@ const rightButton = (props = {}) => {
   }
 
   return {
-    handler: props.navRightHandler || () => {},
+    handler: props.navRightHandler || (() => {}),
     style: props.navRightStyle || {},
     tintColor: props.navRightColor || '#037AFF',
     title: props.navRightTitle || '',


### PR DESCRIPTION
## Changes

* Update example to React Native 0.16
 * Used `react-native update`
 * Changed version in `package.json`
* Fix some details that were incompatible with React Native 0.16
* Add step to documentation on how to run example
 * Basically Babel 6 doesn't like there being `.babelrc` files in `node_modules` other than React Native's own packager's - see https://github.com/facebook/react-native/issues/4062

*Note: Tested on iOS, but not on Android*