### PR TITLE
Update react-native-navbar repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Team Qwikly",
   "license": "MIT",
   "dependencies": {
-    "react-native-navbar": "malkomalko/react-native-navbar",
+    "react-native-navbar": "git+https://github.com/react-native-fellowship/react-native-navbar.git#master",
     "react-native-tabs": "malkomalko/react-native-tabs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Team Qwikly",
   "license": "MIT",
   "dependencies": {
-    "react-native-navbar": "git+https://github.com/react-native-fellowship/react-native-navbar.git#master",
+    "react-native-navbar": "^1.5.0",
     "react-native-tabs": "malkomalko/react-native-tabs"
   }
 }


### PR DESCRIPTION
malkomalko react-native-navbar ver is 1.1.7.
But this version has a bug in Android.
StatusBarIOS.setStyle work only IOS:
```
function customizeStatusBar(data) {
  if (Platform.OS === 'ios') {
    if (data.style) {
      StatusBarIOS.setStyle(data.style, true);
    }
    const animation = data.hidden ?
    (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
    (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);

    StatusBarIOS.setHidden(data.hidden, animation);
  }
}
```
So, You better to change react-navive-navbar repo or update malkomalko/react-native-navbar repo