### PR TITLE
React Native 0.26 - deprecates applied

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Navigator, StyleSheet, View } from 'react-native';
+import React, { Component } from 'react';
+import { Navigator, StyleSheet, View } from 'react-native';
 import Animations from './src/Animations';
 import { NavBar } from './src/NavBar';
 import TabBar from './src/TabBar';

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -1,5 +1,6 @@
+import React, { Component } from 'react';
 import NavigationBar from 'react-native-navbar';
-import React, { Component, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 const leftButton = (props = {}, transitioning) => {
   if (props.navLeft && props.navLeft._isReactElement) {
@@ -42,7 +43,7 @@ const statusBar = props => ({
 
 const title = props => {
   if (props.navTitle && props.navTitle._isReactElement) {
-    return props.navTitle;
+    return navTitle;
   }
 
   return {

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -43,7 +43,7 @@ const statusBar = props => ({
 
 const title = props => {
   if (props.navTitle && props.navTitle._isReactElement) {
-    return navTitle;
+    return props.navTitle;
   }
 
   return {

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -1,5 +1,6 @@
+import React, { Component } from 'react';
 import Tabs from 'react-native-tabs';
-import React, { Component, Image, StyleSheet, Text, View } from 'react-native';
+import { Image, StyleSheet, Text, View } from 'react-native';
 
 const onSelect = props => el => {
   props.actions.changeTab({


### PR DESCRIPTION
For RN 0.26, it is necessary to import Component from 'react' instead of 'react-native'.

This PR make react-native-router-redux compatible to RN 0.26 again, but the required native-bar and button-bar-libraries must be updated also. 

