### PR TITLE
Enable any react element on the tab bar icon part, not only image

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Team Qwikly",
   "license": "MIT",
   "dependencies": {
-    "react-native-navbar": "1.5.x",
-    "react-native-tabs": "1.0.x"
+    "react-native-navbar": "1.5.0",
+    "react-native-tabs": "1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "react-native-navbar": "1.5.0",
-    "react-native-tabs": "1.0.2"
+    "react-native-tabs": "git+https://github.com/rexsun/react-native-tabs.git#e17c09e5769395354b3c3fc4a1c32d7a367aa032"
   }
 }

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -46,12 +46,12 @@ class TabBarIcon extends Component {
 
     return (
       <View name={name} style={tabContainerStyle()}>
-        {tabItem.icon &&
+        {React.isValidElement(tabItem.icon) ? tabItem.icon : (
           <Image
             source={tabItem.icon}
             style={imageStyle(this.props)}
             />
-        }
+        )}
         {tabItem.title &&
           <Text style={textStyle(this.props)}>{tabItem.title}</Text>
         }


### PR DESCRIPTION
I am using vector icons as well, but I am thinking it is better to allow any React elements.

If you don't have a version issue of react-native-tabs, please just ignore my 2 version and dependencies fixes.